### PR TITLE
chore: settings for vscode to ignore the generated routeTree

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"files.watcherExclude": {
+		"**/routeTree.gen.ts": true
+	}
+}


### PR DESCRIPTION
VSCode uses a watcher, that tracks all files within the open workspace. When a file is not open and a change happens to the file in the background, the editor then opens proceeds to open the file onto the active editor. The reason why this breaks your generated `routeTree.gen.ts` file for TanStack Router is because it attempts to open the file whilst a write is going on. This puts the file into an irrecoverable state.

I'll be sure to update the examples projects in our monorepo with this file as well.